### PR TITLE
One method to restart the game

### DIFF
--- a/ConnectFour/ConnectFour/Board.swift
+++ b/ConnectFour/ConnectFour/Board.swift
@@ -90,5 +90,14 @@ class Board {
             playerTurn = .red
         }
     }
+    
+    deinit {
+        for column in columns {
+            column.dropper?.removeFromParent()
+            for cell in column.cells {
+                cell.node?.removeFromParent()
+            }
+        }
+    }
 
 }

--- a/ConnectFour/ConnectFour/GameScene.swift
+++ b/ConnectFour/ConnectFour/GameScene.swift
@@ -21,7 +21,6 @@ class GameScene: SKScene {
     }
     
     private func restartGame() {
-        tearDownBoard()
         board = Board()
         createBoard()
     }
@@ -91,17 +90,5 @@ class GameScene: SKScene {
             y = height / -2 + cellWidth / 2
         }
     }
-    
-    private func tearDownBoard() {
-        for col in board.columns {
-            if let dropper = col.dropper {
-                dropper.removeFromParent()
-            }
-            for cell in col.cells {
-                if let node = cell.node {
-                    node.removeFromParent()
-                }
-            }
-        }
-    }
+
 }

--- a/ConnectFour/ConnectFour/GameScene.swift
+++ b/ConnectFour/ConnectFour/GameScene.swift
@@ -12,8 +12,16 @@ import GameplayKit
 class GameScene: SKScene {
     
     var board: Board!
+    var restartButton: SKLabelNode!
 
     override func didMove(to view: SKView) {
+        createRestartButton()
+        board = Board()
+        createBoard()
+    }
+    
+    private func restartGame() {
+        tearDownBoard()
         board = Board()
         createBoard()
     }
@@ -29,12 +37,24 @@ class GameScene: SKScene {
                         board.updateDisplay()
                     }
                 }
+                if restartButton == touchedNode {
+                    restartGame()
+                }
             }
         }
     }
     
     override func update(_ currentTime: TimeInterval) {
         // Called before each frame is rendered
+    }
+    
+    private func createRestartButton() {
+        restartButton = SKLabelNode(fontNamed: "ArialRoundedMTBold")
+        restartButton.text = "Restart Game"
+        restartButton.fontColor = SKColor.red
+        restartButton.zPosition = 2
+        restartButton.position = CGPoint(x: 0, y: -(frame.size.height / 2) + 100)
+        addChild(restartButton)
     }
     
     private func createBoard() {
@@ -69,6 +89,19 @@ class GameScene: SKScene {
             col.dropper = dropper
             x += cellWidth
             y = height / -2 + cellWidth / 2
+        }
+    }
+    
+    private func tearDownBoard() {
+        for col in board.columns {
+            if let dropper = col.dropper {
+                dropper.removeFromParent()
+            }
+            for cell in col.cells {
+                if let node = cell.node {
+                    node.removeFromParent()
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This change allows restarting the game by tearing down the existing `Board` instance and creating a new one that is built using the `createBoard` method.

The `deinit` method gets called when all references to an object are removed. When `GameScene` reassigns its `board` value to a new instance of `Board`, the old one no longer has any way to refer back to it. (Essentially, there is no longer any variable name we can use to refer to the old `Board` instance once a new one is assigned to `GameScene.board`.) This happens in the `restartGame` function, and when it does, `Board.deinit` is run, which removes all of its nodes on screen.

Note the linked issue (#1 Reset the game board) in the bar to the right. Make sure your PR has the appropriate issue(s) linked as well.