### PR TITLE
A second method to restart the game

### DIFF
--- a/ConnectFour/ConnectFour/Board.swift
+++ b/ConnectFour/ConnectFour/Board.swift
@@ -62,7 +62,11 @@ class Board {
             let newColumn = Column(ofSize: NUM_ROWS)
             columns.append(newColumn)
         }
-        playerTurn = .red
+        playerTurn = Board.selectFirstPlayer()
+    }
+    
+    static func selectFirstPlayer() -> Chip {
+        return .red
     }
     
     func updateDisplay() {
@@ -88,6 +92,19 @@ class Board {
             playerTurn = .black
         } else if playerTurn == .black {
             playerTurn = .red
+        }
+    }
+    
+    func restartGame() {
+        clearBoard()
+        playerTurn = Board.selectFirstPlayer()
+    }
+    
+    func clearBoard() {
+        for column in columns {
+            for cell in column.cells {
+                cell.chip = .empty
+            }
         }
     }
 

--- a/ConnectFour/ConnectFour/GameScene.swift
+++ b/ConnectFour/ConnectFour/GameScene.swift
@@ -12,10 +12,12 @@ import GameplayKit
 class GameScene: SKScene {
     
     var board: Board!
+    var restartButton: SKLabelNode!
 
     override func didMove(to view: SKView) {
         board = Board()
         createBoard()
+        addRestartButton()
     }
     
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
@@ -26,6 +28,10 @@ class GameScene: SKScene {
                 for column in self.board.columns {
                     if let dropper = column.dropper, dropper == touchedNode {
                         board.dropChip(in: column)
+                        board.updateDisplay()
+                    }
+                    if restartButton == touchedNode {
+                        board.restartGame()
                         board.updateDisplay()
                     }
                 }
@@ -70,5 +76,14 @@ class GameScene: SKScene {
             x += cellWidth
             y = height / -2 + cellWidth / 2
         }
+    }
+    
+    private func addRestartButton() {
+        restartButton = SKLabelNode(fontNamed: "ArialRoundedMTBold")
+        restartButton.fontColor = SKColor.red
+        restartButton.text = "Restart Game"
+        restartButton.zPosition = 2
+        restartButton.position = CGPoint(x: 0, y: -frame.size.height / 2 + 100)
+        addChild(restartButton)
     }
 }


### PR DESCRIPTION
This method preserves the existing `Board` instance and sets all of the cell's chips to `.empty` when `GameScene.restartGame` is called.

This also adds a `selectFirstPlayer` function so that, if the method of choosing the first player changes from always being the Red player to, for example, a coin-toss, that wouldn't have to be implemented in two different places.

The `addRestartButton` here does the same thing as the `createRestartButton` in PR #22.

Note the linked issue (#1 Reset the game board) in the bar to the right. Make sure your PR has the appropriate issue(s) linked as well.